### PR TITLE
Updating the achievement that are no longer obtainable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Pull Shark | <img src="https://raw.githubusercontent.com/Schweinepriester/github
 YOLO | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/yolo-default.png" width="175px"> | `✅ Yes` | A user can obtain this badge by merging a pull request without a review (This requires 1 user and 1 reviewer) | Medium
 Quickdraw | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/quickdraw-default.png" width="175px"> | `✅ Yes` | Obtainable by closing a Pull Request or Issue in 5 mins of it being opened. (You can close your own issues) | Very Easy
 Pair Extraordinaire	 | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/pair-extraordinaire-default.png" width="175px"> | `✅ Yes` | The user can obtain this badge by [Coauthoring](https://docs.github.com/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors) in a merged pull request. (Requires GitHub Desktop App) | Hard
-Galaxy Brain | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/galaxy-brain-default.png" width="175px"> | `✅ Yes` | A user can get this badge by getting 2 of their answers accepted on the [Community Discussions](https://github.com/orgs/community/discussions/) forum. | Medium
 Starstruck | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/starstruck-default.png" width="175px"> | `✅ Yes` | This badge is given to someone when one of their repository's gets 16 stars. | Hard
 Public Sponsor | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/public-sponsor-default.png" width="175px"> | `✅ Yes` | This badge can be earned by sponsoring a repository/organization/user. | Very Easy
 
@@ -31,6 +30,7 @@ The following are badges that used to be obtainable, but now cannot be obtained:
 | --- | --- | --- | --- | --- |
 Arctic Code Vault Contributor | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/arctic-code-vault-contributor-default.png" width="175px"> | `❌ No` | Previously obtainable by contributing code to repositories in the [2020 Archive Program](https://archiveprogram.github.com/) | Very Easy
 Mars 2020 Contributor | <img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/mars-2020-contributor-default.png" width="175px"> | `❌ No` | Given if a user contributed code to repositories in the [Mars 2020 Mission](https://github.com/readme/nasa-ingenuity-helicopter) | Easy
+Galaxy Brain |<img src="https://raw.githubusercontent.com/Schweinepriester/github-profile-achievements/main/images/galaxy-brain-default.png" width="175px"> | `❌ No` | A user can get this badge by getting 2 of their answers accepted on the [Community Discussions](https://github.com/orgs/community/discussions/) forum. | Medium
 
 # 🎚️ Tiers
 


### PR DESCRIPTION
According to [this](https://github.com/orgs/community/discussions/106536) announcement, the Galaxy Brain badge is now no longer obtainable, so the file has been updated.